### PR TITLE
fix for https://github.com/quilljs/quill/issues/2585

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -457,10 +457,10 @@ function matchStyles(node, delta) {
     formats.italic = true;
   }
   if (style.textDecoration === 'underline') {
-      formats.underline = true;
+    formats.underline = true;
   }
   if (style.textDecoration === 'line-through') {
-      formats.strike = true;
+    formats.strike = true;
   }
   if (
     style.fontWeight.startsWith('bold') ||

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -456,6 +456,12 @@ function matchStyles(node, delta) {
   if (style.fontStyle === 'italic') {
     formats.italic = true;
   }
+  if (style.textDecoration === 'underline') {
+      formats.underline = true;
+  }
+  if (style.textDecoration === 'line-through') {
+      formats.strike = true;
+  }
   if (
     style.fontWeight.startsWith('bold') ||
     parseInt(style.fontWeight, 10) >= 700


### PR DESCRIPTION
fixing this: CSS style text-decoration: underline and text-decoration: line-through should be converted
into HTML tags <u> and <s>